### PR TITLE
Fix parsing .dic and .aff.

### DIFF
--- a/lib/util/affix.js
+++ b/lib/util/affix.js
@@ -29,17 +29,16 @@ var UTF8 = 'utf8'
 var ALPHABET = 'etaoinshrdlcumwfgypbvkjxqz'.split('')
 
 /* Expressions. */
-var RE_WHITE_SPACE = /\s/
-var RE_INLINE_WHITE_SPACE = / +/
+var RE_WHITE_SPACE = /\s+/
 
 /* Characters. */
 var C_LINE = '\n'
-var C_HASH = '#'
 var C_DOLLAR = '$'
 var C_CARET = '^'
 var C_SLASH = '/'
 var C_DOT = '.'
 var C_0 = '0'
+var CC_HASH = '#'.charCodeAt(0)
 
 /* Defaults. */
 var DEFAULT_COMPOUNDMIN = 3
@@ -95,36 +94,32 @@ function affix(aff) {
   var position
   var rule
   var last
-  var lineEnd
-  var hashIndex
   var value
   var offset
   var character
 
   flags[T_KEY] = []
 
+  function pushLine(line) {
+    line = trim(line)
+    /* Hash can be a valid flag, so we only discard line that starts with it. */
+    if (line && line.charCodeAt(0) !== CC_HASH) {
+      lines.push(line)
+    }
+  }
+
   /* Process the affix buffer into a list of applicable
    * lines. */
   aff = aff.toString(UTF8)
   index = aff.indexOf(C_LINE)
-  hashIndex = aff.indexOf(C_HASH)
   last = 0
 
   while (index !== -1) {
-    if (hashIndex < last) {
-      hashIndex = aff.indexOf(C_HASH, last)
-    }
-
-    lineEnd = hashIndex !== -1 && hashIndex < index ? hashIndex : index
-    line = trim(aff.slice(last, lineEnd))
-
-    if (line) {
-      lines.push(line)
-    }
-
+    pushLine(aff.slice(last, index))
     last = index + 1
     index = aff.indexOf(C_LINE, last)
   }
+  pushLine(aff.slice(last))
 
   /* Process each line. */
   index = -1
@@ -139,7 +134,7 @@ function affix(aff) {
       count = index + parseInt(parts[1], 10)
 
       while (++index <= count) {
-        parts = lines[index].split(RE_INLINE_WHITE_SPACE)
+        parts = lines[index].split(RE_WHITE_SPACE)
         replacementTable.push([parts[1], parts[2]])
       }
 
@@ -149,7 +144,7 @@ function affix(aff) {
       count = index + parseInt(parts[1], 10)
 
       while (++index <= count) {
-        parts = lines[index].split(RE_INLINE_WHITE_SPACE)
+        parts = lines[index].split(RE_WHITE_SPACE)
 
         entry.push([new RegExp(parts[1], 'g'), parts[2]])
       }
@@ -159,7 +154,7 @@ function affix(aff) {
       count = index + parseInt(parts[1], 10)
 
       while (++index <= count) {
-        rule = lines[index].split(RE_INLINE_WHITE_SPACE)[1]
+        rule = lines[index].split(RE_WHITE_SPACE)[1]
         ruleLength = rule.length
         position = -1
 
@@ -184,7 +179,7 @@ function affix(aff) {
       rules[parts[1]] = rule
 
       while (++index <= count) {
-        parts = lines[index].split(RE_INLINE_WHITE_SPACE)
+        parts = lines[index].split(RE_WHITE_SPACE)
         remove = parts[2]
         add = parts[3].split(C_SLASH)
         source = parts[4]

--- a/lib/util/dictionary.js
+++ b/lib/util/dictionary.js
@@ -1,13 +1,18 @@
 'use strict'
 
+var trim = require('trim')
 var parseCodes = require('./rule-codes.js')
 var add = require('./add.js')
 
 module.exports = parse
 
+/* Expressions. */
+var RE_WHITE_SPACE = /\s/g
+
 /* Constants. */
 var UTF8 = 'utf8'
 var C_LINE = '\n'
+var C_HASH = '#'
 var C_SLASH = '/'
 var C_ESCAPE = '\\'
 var CC_TAB = '\t'.charCodeAt(0)
@@ -15,10 +20,6 @@ var CC_TAB = '\t'.charCodeAt(0)
 /* Parse a dictionary. */
 function parse(buf, options, dict) {
   var index
-  var line
-  var word
-  var codes
-  var offset
   var last
   var value
 
@@ -29,26 +30,55 @@ function parse(buf, options, dict) {
 
   while (index !== -1) {
     if (value.charCodeAt(last) !== CC_TAB) {
-      line = value.slice(last, index)
-      word = line
-      codes = []
-
-      offset = line.indexOf(C_SLASH)
-
-      while (offset !== -1) {
-        if (line.charAt(offset - 1) !== C_ESCAPE) {
-          word = line.slice(0, offset)
-          codes = parseCodes(options.flags, line.slice(offset + 1))
-          break
-        }
-
-        offset = line.indexOf(C_SLASH, offset + 1)
-      }
-
-      add(dict, word, codes, options)
+      parseLine(value.slice(last, index), options, dict)
     }
-
     last = index + 1
     index = value.indexOf(C_LINE, last)
+  }
+  parseLine(value.slice(last), options, dict)
+}
+
+/* Parse a line in dictionary. */
+function parseLine(line, options, dict) {
+  var word
+  var codes
+  var result
+  var hashOffset
+  var slashOffset
+
+  /* Find offsets. */
+  slashOffset = line.indexOf(C_SLASH)
+  while (slashOffset !== -1 && line.charAt(slashOffset - 1) === C_ESCAPE) {
+    line = line.slice(0, slashOffset - 1) + line.slice(slashOffset)
+    slashOffset = line.indexOf(C_SLASH, slashOffset)
+  }
+
+  hashOffset = line.indexOf(C_HASH)
+
+  /* Handle hash and slash offsets.
+   * Note that hash can be a valid flag, so we should not just
+   * discard all string after it. */
+  if (hashOffset !== -1) {
+    if (slashOffset !== -1 && slashOffset < hashOffset) {
+      word = line.slice(0, slashOffset)
+      RE_WHITE_SPACE.lastIndex = slashOffset + 1
+      result = RE_WHITE_SPACE.exec(line)
+      codes = line.slice(slashOffset + 1, result? result.index : undefined)
+    } else {
+      word = line.slice(0, hashOffset)
+    }
+  } else {
+    if (slashOffset !== -1) {
+      word = line.slice(0, slashOffset)
+      codes = line.slice(slashOffset + 1)
+    } else {
+      word = line
+    }
+  }
+
+  word = trim(word)
+  if (word) {
+    codes = parseCodes(options.flags, codes && trim(codes))
+    add(dict, word, codes, options)
   }
 }

--- a/lib/util/dictionary.js
+++ b/lib/util/dictionary.js
@@ -58,22 +58,20 @@ function parseLine(line, options, dict) {
   /* Handle hash and slash offsets.
    * Note that hash can be a valid flag, so we should not just
    * discard all string after it. */
-  if (hashOffset !== -1) {
-    if (slashOffset !== -1 && slashOffset < hashOffset) {
+  if (hashOffset >= 0) {
+    if (slashOffset >= 0 && slashOffset < hashOffset) {
       word = line.slice(0, slashOffset)
       RE_WHITE_SPACE.lastIndex = slashOffset + 1
       result = RE_WHITE_SPACE.exec(line)
-      codes = line.slice(slashOffset + 1, result? result.index : undefined)
+      codes = line.slice(slashOffset + 1, result ? result.index : undefined)
     } else {
       word = line.slice(0, hashOffset)
     }
+  } else if (slashOffset >= 0) {
+    word = line.slice(0, slashOffset)
+    codes = line.slice(slashOffset + 1)
   } else {
-    if (slashOffset !== -1) {
-      word = line.slice(0, slashOffset)
-      codes = line.slice(slashOffset + 1)
-    } else {
-      word = line
-    }
+    word = line
   }
 
   word = trim(word)

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -63,7 +63,7 @@ process.on('exit', function() {
   successes = types.true.length
 
   diff = totalTime / misspellings.length
-  percentage = (failures / count * 100).toFixed(2)
+  percentage = ((failures / count) * 100).toFixed(2)
   message = [
     'success: ' + (100 - percentage) + '% (' + successes + ')',
     'fail: ' + percentage + '% (' + failures + ')',

--- a/test/index.js
+++ b/test/index.js
@@ -495,3 +495,34 @@ test('broken dictionaries', function(t) {
     )
   })
 })
+
+test('parse dictionaries', function(t) {
+  t.plan(1)
+
+  t.test('nspell#spell(value)', function(st) {
+    var spell
+
+    spell = nspell(
+      ['SET UTF-8', ''].join('\n'),
+      ['5', 'aaa\\//A', 'bbb/#*', 'ccc/#* #test', 'ddd#/A', 'eee#test'].join(
+        '\n'
+      )
+    )
+
+    st.equal(spell.correct('aaa/'), true, 'should see slash (/) as word')
+
+    st.deepEqual(spell.data.bbb, ['#', '*'], 'should see hash (#) as flag')
+
+    st.deepEqual(
+      spell.data.ccc,
+      ['#', '*'],
+      'should see first hash (#) as flag and second hash as comment'
+    )
+
+    st.equal(spell.correct('ddd'), true, 'should see hash (#) as comment')
+
+    st.equal(spell.correct('eee'), true, 'should see hash (#) as comment')
+
+    st.end()
+  })
+})


### PR DESCRIPTION
1. Fix last line is missing.
2. Some .dic and .aff would use hash symbol (`#`) as flag, so we should not just discard all string after hash.
3. Detect comment after hash symbol when parsing .dic file.