### PR TITLE
switch from dictionary-en-us to dictionary-en

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,13 +45,13 @@ npm install nspell
 You probably also want to install some [dictionaries][]:
 
 ```bash
-npm install dictionary-en-us
+npm install dictionary-en
 ```
 
 ## Usage
 
 ```js
-var dictionary = require('dictionary-en-us')
+var dictionary = require('dictionary-en')
 var nspell = require('nspell')
 
 dictionary(ondictionary)


### PR DESCRIPTION
Hi @wooorm! 👋 

Hope you're doing well! I noticed the package `dictionary-en-us` does not exist, but `dictionary-en` does, so here is a little edit to the readme.