### PR TITLE
Various performance and memory usage optimizations, cutting down initialization time in ~half

### DIFF
--- a/lib/add.js
+++ b/lib/add.js
@@ -4,13 +4,11 @@ var push = require('./util/add.js')
 
 module.exports = add
 
-var own = {}.hasOwnProperty
-
 // Add `value` to the checker.
 function add(value, model) {
   var self = this
   var dict = self.data
-  var codes = model && own.call(dict, model) ? dict[model].concat() : []
+  var codes = dict[model]
 
   push(dict, value, codes, self)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ function NSpell(aff, dic) {
 
   aff = affix(aff)
 
-  this.data = {}
+  this.data = Object.create(null)
   this.compoundRuleCodes = aff.compoundRuleCodes
   this.replacementTable = aff.replacementTable
   this.conversion = aff.conversion

--- a/lib/personal.js
+++ b/lib/personal.js
@@ -1,7 +1,5 @@
 'use strict'
 
-var trim = require('./util/trim.js')
-
 module.exports = add
 
 // Add a dictionary.
@@ -23,7 +21,7 @@ function add(buf) {
   flags.FORBIDDENWORD = flag
 
   while (++index < length) {
-    line = trim(lines[index])
+    line = lines[index].trim()
 
     if (!line) {
       continue

--- a/lib/remove.js
+++ b/lib/remove.js
@@ -6,7 +6,7 @@ module.exports = remove
 function remove(value) {
   var self = this
 
-  self.data[value] = null
+  delete self.data[value]
 
   return self
 }

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var trim = require('./util/trim.js')
 var casing = require('./util/casing.js')
 var normalize = require('./util/normalize.js')
 var flag = require('./util/flag.js')
@@ -51,7 +50,7 @@ function suggest(value) {
   var suggestion
   var currentCase
 
-  value = normalize(trim(value), conversion.in)
+  value = normalize(value.trim(), conversion.in)
 
   if (!value || self.correct(value)) {
     return []

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -141,7 +141,7 @@ function suggest(value) {
     }
   }
 
-  edits = edits.concat(values)
+  edits.push.apply(edits, values)
 
   // Ensure the lower-cased, capitalised, and uppercase values are included.
   values = [value]

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -8,6 +8,8 @@ var form = require('./util/form.js')
 
 module.exports = suggest
 
+var push = [].push
+
 var noSuggestType = 'NOSUGGEST'
 
 // Suggest spelling for `value`.
@@ -141,7 +143,7 @@ function suggest(value) {
     }
   }
 
-  edits.push.apply(edits, values)
+  push.apply(edits, values)
 
   // Ensure the lower-cased, capitalised, and uppercase values are included.
   values = [value]

--- a/lib/util/add.js
+++ b/lib/util/add.js
@@ -15,12 +15,12 @@ function addRules(dict, word, rules) {
   if (word in dict) {
     var curr = dict[word]
     if (curr === NO_RULES) {
-      dict[word] = rules.slice(0)
+      dict[word] = rules.concat()
     } else {
       curr.push.apply(curr, rules)
     }
   } else {
-    dict[word] = rules.slice(0)
+    dict[word] = rules.concat()
   }
 }
 

--- a/lib/util/add.js
+++ b/lib/util/add.js
@@ -5,6 +5,7 @@ var apply = require('./apply.js')
 module.exports = add
 
 var own = {}.hasOwnProperty
+var push = [].push
 
 var NO_RULES = []
 
@@ -17,7 +18,7 @@ function addRules(dict, word, rules) {
     if (curr === NO_RULES) {
       dict[word] = rules.concat()
     } else {
-      curr.push.apply(curr, rules)
+      push.apply(curr, rules)
     }
   } else {
     dict[word] = rules.concat()

--- a/lib/util/add.js
+++ b/lib/util/add.js
@@ -4,7 +4,6 @@ var apply = require('./apply.js')
 
 module.exports = add
 
-var own = {}.hasOwnProperty
 var push = [].push
 
 var NO_RULES = []
@@ -45,7 +44,7 @@ function add(dict, word, codes, options) {
   var newWordCount
 
   // Compound words.
-  if (!own.call(flags, 'NEEDAFFIX') || codes.indexOf(flags.NEEDAFFIX) === -1) {
+  if (!('NEEDAFFIX' in flags) || codes.indexOf(flags.NEEDAFFIX) === -1) {
     addRules(dict, word, codes)
   }
 

--- a/lib/util/add.js
+++ b/lib/util/add.js
@@ -6,6 +6,24 @@ module.exports = add
 
 var own = {}.hasOwnProperty
 
+var NO_RULES = []
+
+// Add `rules` for `word` to the table.
+function addRules(dict, word, rules) {
+  // Some dictionaries will list the same word multiple times with different
+  // rule sets.
+  if (word in dict) {
+    var curr = dict[word]
+    if (curr === NO_RULES) {
+      dict[word] = rules.slice(0)
+    } else {
+      curr.push.apply(curr, rules)
+    }
+  } else {
+    dict[word] = rules.slice(0)
+  }
+}
+
 function add(dict, word, codes, options) {
   var flags = options.flags
   var rules = options.rules
@@ -20,14 +38,17 @@ function add(dict, word, codes, options) {
   var subposition
   var combined
   var otherNewWords
+  var otherNewWord
   var suboffset
   var wordCount
   var newWordCount
 
   // Compound words.
   if (!own.call(flags, 'NEEDAFFIX') || codes.indexOf(flags.NEEDAFFIX) === -1) {
-    add(word, codes)
+    addRules(dict, word, codes)
   }
+
+  if (!codes) return
 
   position = -1
   length = codes.length
@@ -48,7 +69,7 @@ function add(dict, word, codes, options) {
       while (++offset < wordCount) {
         newWord = newWords[offset]
 
-        add(newWord)
+        if (!(newWord in dict)) dict[newWord] = NO_RULES
 
         if (!rule.combineable) {
           continue
@@ -72,18 +93,11 @@ function add(dict, word, codes, options) {
           suboffset = -1
 
           while (++suboffset < newWordCount) {
-            add(otherNewWords[suboffset])
+            otherNewWord = otherNewWords[suboffset]
+            if (!(otherNewWord in dict)) dict[otherNewWord] = NO_RULES
           }
         }
       }
     }
-  }
-
-  // Add `rules` for `word` to the table.
-  function add(word, rules) {
-    // Some dictionaries will list the same word multiple times with different
-    // rule sets.
-    var curr = (own.call(dict, word) && dict[word]) || []
-    dict[word] = curr.concat(rules || [])
   }
 }

--- a/lib/util/add.js
+++ b/lib/util/add.js
@@ -63,7 +63,7 @@ function add(dict, word, codes, options) {
     }
 
     if (rule) {
-      newWords = apply(word, rule, rules)
+      newWords = apply(word, rule, rules, [])
       wordCount = newWords.length
       offset = -1
 
@@ -89,7 +89,7 @@ function add(dict, word, codes, options) {
             continue
           }
 
-          otherNewWords = apply(newWord, combined, rules)
+          otherNewWords = apply(newWord, combined, rules, [])
           newWordCount = otherNewWords.length
           suboffset = -1
 

--- a/lib/util/affix.js
+++ b/lib/util/affix.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var trim = require('./trim.js')
 var parse = require('./rule-codes.js')
 
 module.exports = affix
@@ -287,7 +286,7 @@ function affix(aff) {
   }
 
   function pushLine(line) {
-    line = trim(line)
+    line = line.trim()
 
     // Hash can be a valid flag, so we only discard line that starts with it.
     if (line && line.charCodeAt(0) !== numberSign) {

--- a/lib/util/affix.js
+++ b/lib/util/affix.js
@@ -235,7 +235,7 @@ function affix(aff) {
 
       flags[ruleType] = value
     } else if (ruleType === keyType) {
-      flags[ruleType] = flags[ruleType].concat(parts[1].split('|'))
+      flags[ruleType].push.apply(flags[ruleType], parts[1].split('|'))
     } else if (ruleType === compoundInType) {
       flags[ruleType] = Number(parts[1])
     } else if (ruleType === onlyInCompoundType) {
@@ -268,7 +268,7 @@ function affix(aff) {
 
   /* istanbul ignore if - Dictionaries seem to always have this. */
   if (!flags[tryType]) {
-    flags[tryType] = alphabet.concat()
+    flags[tryType] = alphabet.slice(0)
   }
 
   if (!flags[keepCaseFlag]) {

--- a/lib/util/affix.js
+++ b/lib/util/affix.js
@@ -268,7 +268,7 @@ function affix(aff) {
 
   /* istanbul ignore if - Dictionaries seem to always have this. */
   if (!flags[tryType]) {
-    flags[tryType] = alphabet.slice(0)
+    flags[tryType] = alphabet.concat()
   }
 
   if (!flags[keepCaseFlag]) {

--- a/lib/util/affix.js
+++ b/lib/util/affix.js
@@ -73,12 +73,12 @@ var push = [].push
 // Parse an affix file.
 // eslint-disable-next-line complexity
 function affix(aff) {
-  var rules = {}
+  var rules = Object.create(null)
   var replacementTable = []
   var conversion = {in: [], out: []}
-  var compoundRuleCodes = {}
+  var compoundRuleCodes = Object.create(null)
   var lines = []
-  var flags = {}
+  var flags = Object.create(null)
   var compoundRules = []
   var index
   var length

--- a/lib/util/affix.js
+++ b/lib/util/affix.js
@@ -69,6 +69,8 @@ var defaultKeyboardLayout = [
   'lkm'
 ]
 
+var push = [].push
+
 // Parse an affix file.
 // eslint-disable-next-line complexity
 function affix(aff) {
@@ -235,7 +237,7 @@ function affix(aff) {
 
       flags[ruleType] = value
     } else if (ruleType === keyType) {
-      flags[ruleType].push.apply(flags[ruleType], parts[1].split('|'))
+      push.apply(flags[ruleType], parts[1].split('|'))
     } else if (ruleType === compoundInType) {
       flags[ruleType] = Number(parts[1])
     } else if (ruleType === onlyInCompoundType) {

--- a/lib/util/apply.js
+++ b/lib/util/apply.js
@@ -2,14 +2,9 @@
 
 module.exports = apply
 
-var NO_WORDS = []
-
-var push = [].push
-
 // Apply a rule.
-function apply(value, rule, rules) {
+function apply(value, rule, rules, words) {
   var entries = rule.entries
-  var words = NO_WORDS
   var index = -1
   var length = entries.length
   var entry
@@ -35,11 +30,7 @@ function apply(value, rule, rules) {
         next = entry.add + next
       }
 
-      if (words === NO_WORDS) {
-        words = [next]
-      } else {
-        words.push(next)
-      }
+      words.push(next)
 
       continuation = entry.continuation
 
@@ -51,7 +42,7 @@ function apply(value, rule, rules) {
           continuationRule = rules[continuation[position]]
 
           if (continuationRule) {
-            push.apply(words, apply(next, continuationRule, rules))
+            apply(next, continuationRule, rules, words)
           }
         }
       }

--- a/lib/util/apply.js
+++ b/lib/util/apply.js
@@ -2,10 +2,12 @@
 
 module.exports = apply
 
+var NO_WORDS = []
+
 // Apply a rule.
 function apply(value, rule, rules) {
   var entries = rule.entries
-  var words = []
+  var words = NO_WORDS
   var index = -1
   var length = entries.length
   var entry
@@ -18,7 +20,7 @@ function apply(value, rule, rules) {
   while (++index < length) {
     entry = entries[index]
 
-    if (!entry.match || value.match(entry.match)) {
+    if (!entry.match || entry.match.test(value)) {
       next = value
 
       if (entry.remove) {
@@ -31,7 +33,11 @@ function apply(value, rule, rules) {
         next = entry.add + next
       }
 
-      words.push(next)
+      if (words === NO_WORDS) {
+        words = [next]
+      } else {
+        words.push(next)
+      }
 
       continuation = entry.continuation
 
@@ -43,7 +49,7 @@ function apply(value, rule, rules) {
           continuationRule = rules[continuation[position]]
 
           if (continuationRule) {
-            words = words.concat(apply(next, continuationRule, rules))
+            words.push.apply(words, apply(next, continuationRule, rules))
           }
         }
       }

--- a/lib/util/apply.js
+++ b/lib/util/apply.js
@@ -4,6 +4,8 @@ module.exports = apply
 
 var NO_WORDS = []
 
+var push = [].push
+
 // Apply a rule.
 function apply(value, rule, rules) {
   var entries = rule.entries
@@ -49,7 +51,7 @@ function apply(value, rule, rules) {
           continuationRule = rules[continuation[position]]
 
           if (continuationRule) {
-            words.push.apply(words, apply(next, continuationRule, rules))
+            push.apply(words, apply(next, continuationRule, rules))
           }
         }
       }

--- a/lib/util/dictionary.js
+++ b/lib/util/dictionary.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var trim = require('./trim.js')
 var parseCodes = require('./rule-codes.js')
 var add = require('./add.js')
 
@@ -75,9 +74,9 @@ function parseLine(line, options, dict) {
     word = line
   }
 
-  word = trim(word)
+  word = word.trim()
   if (word) {
-    codes = parseCodes(options.flags, codes && trim(codes))
+    codes = parseCodes(options.flags, codes && codes.trim())
     add(dict, word, codes, options)
   }
 }

--- a/lib/util/exact.js
+++ b/lib/util/exact.js
@@ -4,13 +4,11 @@ var flag = require('./flag.js')
 
 module.exports = exact
 
-var own = {}.hasOwnProperty
-
 // Check spelling of `value`, exactly.
 function exact(context, value) {
   var data = context.data
   var flags = context.flags
-  var codes = own.call(data, value) ? data[value] : null
+  var codes = data[value]
   var compound
   var index
   var length

--- a/lib/util/exact.js
+++ b/lib/util/exact.js
@@ -26,7 +26,7 @@ function exact(context, value) {
   // Check if this might be a compound word.
   if (value.length >= flags.COMPOUNDMIN) {
     while (++index < length) {
-      if (value.match(compound[index])) {
+      if (compound[index].test(value)) {
         return true
       }
     }

--- a/lib/util/flag.js
+++ b/lib/util/flag.js
@@ -2,9 +2,7 @@
 
 module.exports = flag
 
-var own = {}.hasOwnProperty
-
 // Check whether a word has a flag.
 function flag(values, value, flags) {
-  return flags && own.call(values, value) && flags.indexOf(values[value]) !== -1
+  return flags && value in values && flags.indexOf(values[value]) !== -1
 }

--- a/lib/util/form.js
+++ b/lib/util/form.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var normalize = require('./normalize.js')
-var trim = require('./trim.js')
 var exact = require('./exact.js')
 var flag = require('./flag.js')
 
@@ -13,7 +12,7 @@ function form(context, value, all) {
   var flags = context.flags
   var alternative
 
-  value = trim(value)
+  value = value.trim()
 
   if (!value) {
     return null

--- a/lib/util/rule-codes.js
+++ b/lib/util/rule-codes.js
@@ -2,23 +2,25 @@
 
 module.exports = ruleCodes
 
+var NO_CODES = []
+
 // Parse rule codes.
 function ruleCodes(flags, value) {
   var flag = flags.FLAG
-  var result = []
+  var result
   var length
   var index
 
-  if (!value) {
-    return result
-  }
+  if (!value) return NO_CODES
 
   if (flag === 'long') {
     index = 0
     length = value.length
 
+    result = new Array(Math.ceil(length / 2))
+
     while (index < length) {
-      result.push(value.slice(index, index + 2))
+      result[index / 2] = value.slice(index, index + 2)
 
       index += 2
     }

--- a/lib/util/rule-codes.js
+++ b/lib/util/rule-codes.js
@@ -17,6 +17,8 @@ function ruleCodes(flags, value) {
     index = 0
     length = value.length
 
+    // Creating an array of the right length immediately
+    // avoiding resizes and using memory more efficiently
     result = new Array(Math.ceil(length / 2))
 
     while (index < length) {

--- a/lib/util/trim.js
+++ b/lib/util/trim.js
@@ -1,9 +1,0 @@
-'use strict'
-
-var re = /^\s*|\s*$/g
-
-module.exports = trim
-
-function trim(value) {
-  return value.replace(re, '')
-}


### PR DESCRIPTION
With the optimizations contained in this PR the time required to parse `dictionary-fr` went down from this:

![image](https://user-images.githubusercontent.com/1812093/93771500-7ffcad00-fc15-11ea-8e30-9ad2edf3bb34.png)

To this:

![image](https://user-images.githubusercontent.com/1812093/93771509-82f79d80-fc15-11ea-9dec-c14aea3a8b7b.png)

This closes #31, as serializing parsed dictionaries doesn't really seem to be a viable strategy, but addressing some of the performance issues lead to significant improvements. There probably is still some room for improvement but I ran out of ideas, building an object with millions of properties just seems inherently pretty expensive.