### PR TITLE
Reduce memory usage and initialization time by 40% by using maps rather than plain objects

### DIFF
--- a/lib/add.js
+++ b/lib/add.js
@@ -10,7 +10,7 @@ var NO_CODES = []
 function add(value, model) {
   var self = this
   var dict = self.data
-  var codes = dict[model] || NO_CODES
+  var codes = dict.get(model) || NO_CODES
 
   push(dict, value, codes, self)
 

--- a/lib/add.js
+++ b/lib/add.js
@@ -4,11 +4,13 @@ var push = require('./util/add.js')
 
 module.exports = add
 
+var NO_CODES = []
+
 // Add `value` to the checker.
 function add(value, model) {
   var self = this
   var dict = self.data
-  var codes = dict[model]
+  var codes = dict[model] || NO_CODES
 
   push(dict, value, codes, self)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ function NSpell(aff, dic) {
 
   aff = affix(aff)
 
-  this.data = Object.create(null)
+  this.data = new Map()
   this.compoundRuleCodes = aff.compoundRuleCodes
   this.replacementTable = aff.replacementTable
   this.conversion = aff.conversion

--- a/lib/personal.js
+++ b/lib/personal.js
@@ -41,7 +41,7 @@ function add(buf) {
     self.add(word, model, NO_CODES)
 
     if (forbidden) {
-      self.data[word].push(flag)
+      self.data.get(word).push(flag)
     }
   }
 

--- a/lib/personal.js
+++ b/lib/personal.js
@@ -2,8 +2,6 @@
 
 module.exports = add
 
-var NO_CODES = []
-
 // Add a dictionary.
 function add(buf) {
   var self = this
@@ -38,7 +36,7 @@ function add(buf) {
       word = word.slice(1)
     }
 
-    self.add(word, model, NO_CODES)
+    self.add(word, model)
 
     if (forbidden) {
       self.data.get(word).push(flag)

--- a/lib/personal.js
+++ b/lib/personal.js
@@ -2,6 +2,8 @@
 
 module.exports = add
 
+var NO_CODES = []
+
 // Add a dictionary.
 function add(buf) {
   var self = this
@@ -36,7 +38,7 @@ function add(buf) {
       word = word.slice(1)
     }
 
-    self.add(word, model)
+    self.add(word, model, NO_CODES)
 
     if (forbidden) {
       self.data[word].push(flag)

--- a/lib/remove.js
+++ b/lib/remove.js
@@ -6,7 +6,7 @@ module.exports = remove
 function remove(value) {
   var self = this
 
-  delete self.data[value]
+  self.data.delete(value)
 
   return self
 }

--- a/lib/spell.js
+++ b/lib/spell.js
@@ -16,7 +16,7 @@ function spell(word) {
   // (whether `word` was compound).
   return {
     correct: self.correct(word),
-    forbidden: Boolean(value && flag(flags, 'FORBIDDENWORD', dict[value])),
-    warn: Boolean(value && flag(flags, 'WARN', dict[value]))
+    forbidden: Boolean(value && flag(flags, 'FORBIDDENWORD', dict.get(value))),
+    warn: Boolean(value && flag(flags, 'WARN', dict.get(value)))
   }
 }

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -336,7 +336,7 @@ function generate(context, memory, words, edits) {
       result.push(value)
 
       corrected = form(context, value)
-      state = corrected && !flag(flags, noSuggestType, data[corrected])
+      state = corrected && !flag(flags, noSuggestType, data.get(corrected))
 
       memory.state[value] = state
 

--- a/lib/util/add.js
+++ b/lib/util/add.js
@@ -12,15 +12,15 @@ var NO_RULES = []
 function addRules(dict, word, rules) {
   // Some dictionaries will list the same word multiple times with different
   // rule sets.
-  if (word in dict) {
-    var curr = dict[word]
+  if (dict.has(word)) {
+    var curr = dict.get(word)
     if (curr === NO_RULES) {
-      dict[word] = rules.concat()
+      dict.set(word, rules.concat())
     } else {
       push.apply(curr, rules)
     }
   } else {
-    dict[word] = rules.concat()
+    dict.set(word, rules.concat())
   }
 }
 
@@ -67,7 +67,7 @@ function add(dict, word, codes, options) {
       while (++offset < wordCount) {
         newWord = newWords[offset]
 
-        if (!(newWord in dict)) dict[newWord] = NO_RULES
+        if (!dict.has(newWord)) dict.set(newWord, NO_RULES)
 
         if (!rule.combineable) {
           continue
@@ -92,7 +92,7 @@ function add(dict, word, codes, options) {
 
           while (++suboffset < newWordCount) {
             otherNewWord = otherNewWords[suboffset]
-            if (!(otherNewWord in dict)) dict[otherNewWord] = NO_RULES
+            if (!dict.has(otherNewWord)) dict.set(otherNewWord, NO_RULES)
           }
         }
       }

--- a/lib/util/add.js
+++ b/lib/util/add.js
@@ -48,8 +48,6 @@ function add(dict, word, codes, options) {
     addRules(dict, word, codes)
   }
 
-  if (!codes) return
-
   position = -1
   length = codes.length
 

--- a/lib/util/exact.js
+++ b/lib/util/exact.js
@@ -8,7 +8,7 @@ module.exports = exact
 function exact(context, value) {
   var data = context.data
   var flags = context.flags
-  var codes = data[value]
+  var codes = data.get(value)
   var compound
   var index
   var length

--- a/lib/util/form.js
+++ b/lib/util/form.js
@@ -21,7 +21,7 @@ function form(context, value, all) {
   value = normalize(value, context.conversion.in)
 
   if (exact(context, value)) {
-    if (!all && flag(flags, 'FORBIDDENWORD', dict[value])) {
+    if (!all && flag(flags, 'FORBIDDENWORD', dict.get(value))) {
       return null
     }
 
@@ -32,7 +32,7 @@ function form(context, value, all) {
   if (value.toUpperCase() === value) {
     alternative = value.charAt(0) + value.slice(1).toLowerCase()
 
-    if (ignore(flags, dict[alternative], all)) {
+    if (ignore(flags, dict.get(alternative), all)) {
       return null
     }
 
@@ -45,7 +45,7 @@ function form(context, value, all) {
   alternative = value.toLowerCase()
 
   if (alternative !== value) {
-    if (ignore(flags, dict[alternative], all)) {
+    if (ignore(flags, dict.get(alternative), all)) {
       return null
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -546,10 +546,14 @@ test('parse dictionaries', function (t) {
 
     st.equal(spell.correct('aaa/'), true, 'should see slash (/) as word')
 
-    st.deepEqual(spell.data.bbb, ['#', '*'], 'should see hash (#) as flag')
+    st.deepEqual(
+      spell.data.get('bbb'),
+      ['#', '*'],
+      'should see hash (#) as flag'
+    )
 
     st.deepEqual(
-      spell.data.ccc,
+      spell.data.get('ccc'),
       ['#', '*'],
       'should see first hash (#) as flag and second hash as comment'
     )


### PR DESCRIPTION
Benchmarks performed by initializing the french dictionary, on node v14 and using the version of nspell that includes the previous performance optimizations I submitted.

## Before

CPU usage:

![image](https://user-images.githubusercontent.com/1812093/95529858-0e25b100-09d4-11eb-8712-7386a1a1876f.png)

RAM usage:

![image](https://user-images.githubusercontent.com/1812093/95529933-4c22d500-09d4-11eb-835b-dc194ed2ed16.png)

## After

CPU usage:

![image](https://user-images.githubusercontent.com/1812093/95529946-580e9700-09d4-11eb-8f17-8e798aeb7d3e.png)

RAM usage:

![image](https://user-images.githubusercontent.com/1812093/95529957-60ff6880-09d4-11eb-9c91-a6e05634665a.png)

## Summary

- Pros:
  - CPU usage went down by a further ~40%, now on my machine nspell takes ~800ms to run the regexes, ~800ms to check for the existence of the potential new words in the dictionary, ~1.5s to add new keys to the dictionary map, and another ~200ms doing other things. There's basically near zero room for further optimizations on our end I think, unless using some other data structure for some reason makes the engine run the code faster.
  - RAM usage went down by ~40% too, which for the french dictionary that means ~160MB less RAM needed, which I think is pretty significant. Also while running the profiler the peak memory used went from ~600MB to ~250MB, but I'm not sure how reliable that counter is.
- Cons:
  - A Map now is used rather than a plain object for storing the dictionary, which is what provided the performance gains in this PR.
  - As the `data` property is meant to be exposed making it a Map makes this a potentially breaking change.
  - A native Map implementation must be available for these gains to materialize, otherwise we'd obviously still be dealing with plain objects under the hood.
  - A somewhat recent version of v8 is needed, as running the benchmark on node v12.12 (v8 v7.something) made this actually significantly slower than before (~8s rather than the previous ~6s), but running it on node 14 (v8 v8.something) made this run at the reported speeds.

The cons fortunately are not relevant for me, but if supporting IE10 or something is more important for nspell than the performance gains feel free not to merge this PR. IMHO publishing this as v3 would be the best option.