### PR TITLE
Check for uppercase at each position when adding keyboard edits

### DIFF
--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -35,6 +35,7 @@ function suggest(value) {
   var character
   var group
   var before
+  var between
   var after
   var upper
   var insensitive
@@ -78,7 +79,6 @@ function suggest(value) {
   while (++index < length) {
     character = value.charAt(index)
     insensitive = character.toLowerCase()
-    upper = insensitive !== character
     offset = -1
     count = groups.length
 
@@ -91,6 +91,8 @@ function suggest(value) {
       }
 
       before = value.slice(0, position)
+      between = value[position] || value.slice(-1)
+      upper = between !== between.toLowerCase()
       after = value.slice(position + 1)
       otherOffset = -1
       otherCount = group.length


### PR DESCRIPTION
This addresses [a `retext-spell` issue](https://github.com/retextjs/retext-spell/issues/20) I've discovered that is fundamentally [an `nspell` issue](https://github.com/wooorm/nspell/issues/37).

I'm including a concrete example of the problem for reference.

Differences from `main` are **bolded**:

#### One Example I've tested

- assume the input word is "Twinz"
- assume character `a`is "t" at index 0

1. **We ignore that "T" is uppercase in "Twinz".**
2. The first group is "qwertzuop".
    1. We know the position of "t" in the group is 4.
    2. We split the word "Twinz" at position 4 into `before`="Twin" and `after` = ""
    3. We iterate thrice to group character `b`="e" 
        - We select **lowercase** "e" for index 4 because "z" was **lowercase at index 4**

This is how we (confusingly) arrive at the correct suggestion of **"Twine"**.

## Ignoring a bigger problem

In `main`, the notion of "Keyboard groups" doesn't really make sense as it replaces at a position (of `a` in group) that is unrelated to the original position (of `a` in word). **This solution ignores that "root problem."**

For another solution, see [my related PR](https://github.com/wooorm/nspell/pull/39).

Following the approach of `main`, this solution **splits the word at the unrelated position** of character `a` in the keyboard group. Working within that constraint, this solution **uses the case of character that will be replaced** to decide the case of the replacement character. See my review comments.