### PR TITLE
Fix caps, keyboard group logic

### DIFF
--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -152,12 +152,14 @@ function suggest(value) {
 
   push.apply(edits, values)
 
-  // Ensure the capitalised and uppercase values are included.
+  // Ensure the lower-cased, capitalised, and uppercase values are included.
   values = [value]
   replacement = value.toLowerCase()
 
-  if (value === replacement || currentCase === null) {
+  if (value === replacement) {
     values.push(value.charAt(0).toUpperCase() + replacement.slice(1))
+  } else {
+    values.push(replacement)
   }
 
   replacement = value.toUpperCase()
@@ -255,7 +257,6 @@ function generate(context, memory, words, edits) {
   var flags = context.flags
   var result = []
   var upper
-  var nextUpper
   var length
   var index
   var word
@@ -269,7 +270,6 @@ function generate(context, memory, words, edits) {
   var nextCharacter
   var inject
   var offset
-  var currentCase
 
   // Check the pre-generated edits.
   length = edits && edits.length
@@ -289,10 +289,8 @@ function generate(context, memory, words, edits) {
     before = ''
     character = ''
     nextAfter = word
-    currentCase = casing(word)
     nextNextAfter = word.slice(1)
     nextCharacter = word.charAt(0)
-    nextUpper = nextCharacter.toLowerCase() !== nextCharacter
     position = -1
     count = word.length + 1
 
@@ -304,23 +302,7 @@ function generate(context, memory, words, edits) {
       nextNextAfter = nextAfter.slice(1)
       character = nextCharacter
       nextCharacter = word.charAt(position + 1)
-      upper = nextUpper
-      if (nextCharacter) {
-        nextUpper = nextCharacter.toLowerCase() !== nextCharacter
-      }
-
-      if (nextAfter && upper !== nextUpper) {
-        // Remove.
-        check(before + switchCase(nextAfter))
-
-        // Switch.
-        check(
-          before +
-            switchCase(nextCharacter) +
-            switchCase(character) +
-            nextNextAfter
-        )
-      }
+      upper = character.toLowerCase() !== character
 
       // Remove.
       check(before + nextAfter)
@@ -336,19 +318,14 @@ function generate(context, memory, words, edits) {
       while (++offset < characterLength) {
         inject = characters[offset]
 
+        // Add and replace.
+        check(before + inject + after)
+        check(before + inject + nextAfter)
+
         // Try upper-case if the original character was upper-cased.
         if (upper && inject !== inject.toUpperCase()) {
-          if (currentCase !== 's') {
-            check(before + inject + after)
-            check(before + inject + nextAfter)
-          }
-
           inject = inject.toUpperCase()
 
-          check(before + inject + after)
-          check(before + inject + nextAfter)
-        } else {
-          // Add and replace.
           check(before + inject + after)
           check(before + inject + nextAfter)
         }
@@ -381,14 +358,5 @@ function generate(context, memory, words, edits) {
     if (state) {
       memory.weighted[value]++
     }
-  }
-
-  function switchCase(fragment) {
-    var first = fragment.charAt(0)
-    if (first.toLowerCase() === first) {
-      return first.toUpperCase() + fragment.slice(1)
-    }
-
-    return first.toLowerCase() + fragment.slice(1)
   }
 }

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -23,6 +23,7 @@ function suggest(value) {
   var memory
   var replacement
   var edits = []
+  var addedCharacters = []
   var values
   var index
   var length
@@ -83,6 +84,7 @@ function suggest(value) {
     upper = insensitive !== character
     offset = -1
     count = groups.length
+    addedCharacters = []
 
     while (++offset < count) {
       group = groups[offset]
@@ -98,6 +100,12 @@ function suggest(value) {
       while (++otherOffset < otherCount) {
         if (otherOffset !== position) {
           otherCharacter = group.charAt(otherOffset)
+          // Disallow duplicate replacements for each index
+          if (addedCharacters.includes(otherCharacter)) {
+            continue
+          }
+
+          addedCharacters.push(otherCharacter)
 
           if (upper) {
             otherCharacter = otherCharacter.toUpperCase()

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -77,6 +77,8 @@ function suggest(value) {
 
   while (++index < length) {
     character = value.charAt(index)
+    before = value.slice(0, index)
+    after = value.slice(index + 1)
     insensitive = character.toLowerCase()
     upper = insensitive !== character
     offset = -1
@@ -90,8 +92,6 @@ function suggest(value) {
         continue
       }
 
-      before = value.slice(0, position)
-      after = value.slice(position + 1)
       otherOffset = -1
       otherCount = group.length
 

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -18,7 +18,6 @@ function suggest(value) {
   var replacementTable = self.replacementTable
   var conversion = self.conversion
   var groups = self.flags.KEY
-  var offsetAdded = []
   var charAdded = {}
   var suggestions = []
   var weighted = {}
@@ -50,10 +49,8 @@ function suggest(value) {
   var normalized
   var suggestion
   var currentCase
-  var valueLowerCase
 
   value = normalize(value.trim(), conversion.in)
-  valueLowerCase = value.toLowerCase()
 
   if (!value || self.correct(value)) {
     return []
@@ -76,35 +73,33 @@ function suggest(value) {
   }
 
   // Check the keyboard.
-  length = groups.length
+  length = value.length
   index = -1
 
   while (++index < length) {
-    group = groups[index]
-    // Only make edits to the start of value, bound by group size
-    count = Math.min(value.length, group.length)
+    character = value.charAt(index)
+    before = value.slice(0, index)
+    after = value.slice(index + 1)
+    insensitive = character.toLowerCase()
+    upper = insensitive !== character
+    charAdded = {}
+
     offset = -1
+    count = groups.length
 
     while (++offset < count) {
-      // Consider edits where value contains character at offset in group
-      position = valueLowerCase.indexOf(group.charAt(offset))
+      group = groups[offset]
+      position = group.indexOf(insensitive)
 
       if (position === -1) {
         continue
       }
 
-      character = value.charAt(offset)
-      insensitive = character.toLowerCase()
-      upper = insensitive !== character
-      charAdded = offsetAdded[offset] || {}
-
-      before = value.slice(0, offset)
-      after = value.slice(offset + 1)
       otherOffset = -1
       otherCount = group.length
 
       while (++otherOffset < otherCount) {
-        if (otherOffset !== offset) {
+        if (otherOffset !== position) {
           otherCharacter = group.charAt(otherOffset)
 
           if (charAdded[otherCharacter]) {
@@ -120,8 +115,6 @@ function suggest(value) {
           edits.push(before + otherCharacter + after)
         }
       }
-
-      offsetAdded[offset] = charAdded
     }
   }
 

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -152,14 +152,12 @@ function suggest(value) {
 
   push.apply(edits, values)
 
-  // Ensure the lower-cased, capitalised, and uppercase values are included.
+  // Ensure the capitalised and uppercase values are included.
   values = [value]
   replacement = value.toLowerCase()
 
   if (value === replacement) {
     values.push(value.charAt(0).toUpperCase() + replacement.slice(1))
-  } else {
-    values.push(replacement)
   }
 
   replacement = value.toUpperCase()
@@ -257,6 +255,7 @@ function generate(context, memory, words, edits) {
   var flags = context.flags
   var result = []
   var upper
+  var nextUpper
   var length
   var index
   var word
@@ -270,6 +269,7 @@ function generate(context, memory, words, edits) {
   var nextCharacter
   var inject
   var offset
+  var currentCase
 
   // Check the pre-generated edits.
   length = edits && edits.length
@@ -289,8 +289,10 @@ function generate(context, memory, words, edits) {
     before = ''
     character = ''
     nextAfter = word
+    currentCase = casing(word)
     nextNextAfter = word.slice(1)
     nextCharacter = word.charAt(0)
+    nextUpper = nextCharacter.toLowerCase() !== nextCharacter
     position = -1
     count = word.length + 1
 
@@ -302,7 +304,23 @@ function generate(context, memory, words, edits) {
       nextNextAfter = nextAfter.slice(1)
       character = nextCharacter
       nextCharacter = word.charAt(position + 1)
-      upper = character.toLowerCase() !== character
+      upper = nextUpper
+      if (nextCharacter) {
+        nextUpper = nextCharacter.toLowerCase() !== nextCharacter
+      }
+
+      if (nextAfter && upper !== nextUpper) {
+        // Remove.
+        check(before + switchCase(nextAfter))
+
+        // Switch.
+        check(
+          before +
+            switchCase(nextCharacter) +
+            switchCase(character) +
+            nextNextAfter
+        )
+      }
 
       // Remove.
       check(before + nextAfter)
@@ -318,14 +336,19 @@ function generate(context, memory, words, edits) {
       while (++offset < characterLength) {
         inject = characters[offset]
 
-        // Add and replace.
-        check(before + inject + after)
-        check(before + inject + nextAfter)
-
         // Try upper-case if the original character was upper-cased.
         if (upper && inject !== inject.toUpperCase()) {
+          if (currentCase !== 's') {
+            check(before + inject + after)
+            check(before + inject + nextAfter)
+          }
+
           inject = inject.toUpperCase()
 
+          check(before + inject + after)
+          check(before + inject + nextAfter)
+        } else {
+          // Add and replace.
           check(before + inject + after)
           check(before + inject + nextAfter)
         }
@@ -358,5 +381,14 @@ function generate(context, memory, words, edits) {
     if (state) {
       memory.weighted[value]++
     }
+  }
+
+  function switchCase(fragment) {
+    var first = fragment.charAt(0)
+    if (first.toLowerCase() === first) {
+      return first.toUpperCase() + fragment.slice(1)
+    }
+
+    return first.toLowerCase() + fragment.slice(1)
   }
 }

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -18,12 +18,13 @@ function suggest(value) {
   var replacementTable = self.replacementTable
   var conversion = self.conversion
   var groups = self.flags.KEY
+  var offsetAdded = []
+  var charAdded = {}
   var suggestions = []
   var weighted = {}
   var memory
   var replacement
   var edits = []
-  var addedCharacters = []
   var values
   var index
   var length
@@ -49,8 +50,10 @@ function suggest(value) {
   var normalized
   var suggestion
   var currentCase
+  var valueLowerCase
 
   value = normalize(value.trim(), conversion.in)
+  valueLowerCase = value.toLowerCase()
 
   if (!value || self.correct(value)) {
     return []
@@ -73,39 +76,42 @@ function suggest(value) {
   }
 
   // Check the keyboard.
-  length = value.length
+  length = groups.length
   index = -1
 
   while (++index < length) {
-    character = value.charAt(index)
-    before = value.slice(0, index)
-    after = value.slice(index + 1)
-    insensitive = character.toLowerCase()
-    upper = insensitive !== character
+    group = groups[index]
+    // Only make edits to the start of value, bound by group size
+    count = Math.min(value.length, group.length)
     offset = -1
-    count = groups.length
-    addedCharacters = []
 
     while (++offset < count) {
-      group = groups[offset]
-      position = group.indexOf(insensitive)
+      // Consider edits where value contains character at offset in group
+      position = valueLowerCase.indexOf(group.charAt(offset))
 
       if (position === -1) {
         continue
       }
 
+      character = value.charAt(offset)
+      insensitive = character.toLowerCase()
+      upper = insensitive !== character
+      charAdded = offsetAdded[offset] || {}
+
+      before = value.slice(0, offset)
+      after = value.slice(offset + 1)
       otherOffset = -1
       otherCount = group.length
 
       while (++otherOffset < otherCount) {
-        if (otherOffset !== position) {
+        if (otherOffset !== offset) {
           otherCharacter = group.charAt(otherOffset)
-          // Disallow duplicate replacements for each index
-          if (addedCharacters.includes(otherCharacter)) {
+
+          if (charAdded[otherCharacter]) {
             continue
           }
 
-          addedCharacters.push(otherCharacter)
+          charAdded[otherCharacter] = true
 
           if (upper) {
             otherCharacter = otherCharacter.toUpperCase()
@@ -114,6 +120,8 @@ function suggest(value) {
           edits.push(before + otherCharacter + after)
         }
       }
+
+      offsetAdded[offset] = charAdded
     }
   }
 

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -156,7 +156,7 @@ function suggest(value) {
   values = [value]
   replacement = value.toLowerCase()
 
-  if (value === replacement) {
+  if (value === replacement || currentCase === null) {
     values.push(value.charAt(0).toUpperCase() + replacement.slice(1))
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -263,18 +263,7 @@ test('NSpell()', function (t) {
 
     st.deepEqual(
       us.suggest('Ghandi'),
-      [
-        'Brandi',
-        'Ghana',
-        'Grandee',
-        'Hand',
-        'Hands',
-        'Handy',
-        'Hanoi',
-        'Hindi',
-        'Randi',
-        'Shanxi'
-      ],
+      ['Brandi', 'Ghana', 'Grandee', 'Shanxi', 'hand', 'hands', 'handy'],
       'should suggest alternatives'
     )
 
@@ -490,11 +479,12 @@ test('NSpell()', function (t) {
       us.suggest('dont'),
       [
         'cont',
+        'font',
         'dent',
         'dint',
         'done',
         'dong',
-        'font',
+        'wont',
         'dolt',
         'don',
         "don't",
@@ -502,36 +492,17 @@ test('NSpell()', function (t) {
         'dons',
         'dost',
         'dot',
-        'wont',
         'Donn',
         'Mont',
-        'Ont'
+        'ONT'
       ],
       'should suggest alternatives including correct conjunction'
     )
 
     st.deepEqual(
-      us.suggest('Iffect'),
-      ['Affect', 'Effect', 'Infect'],
-      'should suggest sentence-case with replaced first character'
-    )
-
-    st.deepEqual(
-      us.suggest('Acnada'),
-      ['Canada'],
-      'should suggest sentence-case with swapped first character'
-    )
-
-    st.deepEqual(
-      us.suggest('abDUL'),
-      ['Abdul'],
-      'should suggest sentence-case for funky case when sentence-case in dictionary'
-    )
-
-    st.deepEqual(
-      us.suggest('COLORFU'),
-      ['COLORFUL'],
-      'should suggest alternatives for upper-case with added letter'
+      us.suggest('ToDo'),
+      ['doDo', 'TOD', 'TODD', 'Togo', 'Tojo', 'too', 'Toto'],
+      'TODO: This test behaves unexpectedly, but is needed for coverage.'
     )
 
     st.end()

--- a/test/index.js
+++ b/test/index.js
@@ -263,7 +263,18 @@ test('NSpell()', function (t) {
 
     st.deepEqual(
       us.suggest('Ghandi'),
-      ['Brandi', 'Ghana', 'Grandee', 'Shanxi', 'hand', 'hands', 'handy'],
+      [
+        'Brandi',
+        'Ghana',
+        'Grandee',
+        'Hand',
+        'Hands',
+        'Handy',
+        'Hanoi',
+        'Hindi',
+        'Randi',
+        'Shanxi'
+      ],
       'should suggest alternatives'
     )
 
@@ -497,6 +508,24 @@ test('NSpell()', function (t) {
         'ONT'
       ],
       'should suggest alternatives including correct conjunction'
+    )
+
+    st.deepEqual(
+      us.suggest('Iffect'),
+      ['Affect', 'Effect', 'Infect'],
+      'should suggest sentence-case with replaced first character'
+    )
+
+    st.deepEqual(
+      us.suggest('Acnada'),
+      ['Canada'],
+      'should suggest sentence-case with swapped first character'
+    )
+
+    st.deepEqual(
+      us.suggest('COLORFU'),
+      ['COLORFUL'],
+      'should suggest alternatives for upper-case with added letter'
     )
 
     st.end()

--- a/test/index.js
+++ b/test/index.js
@@ -500,9 +500,9 @@ test('NSpell()', function (t) {
     )
 
     st.deepEqual(
-      us.suggest('ToDo'),
-      ['doDo', 'TOD', 'TODD', 'Togo', 'Tojo', 'too', 'Toto'],
-      'TODO: This test behaves unexpectedly, but is needed for coverage.'
+      us.suggest('TODO'),
+      [`DODO`, `TOD`, `TODD`, `TOGO`, `TOJO`, `TOO`, `TOTO`],
+      'should suggest alternatives for uppercase input'
     )
 
     st.end()

--- a/test/index.js
+++ b/test/index.js
@@ -257,13 +257,13 @@ test('NSpell()', function (t) {
 
     st.deepEqual(
       us.suggest('propper'),
-      ['dropper', 'proper', 'cropper', 'popper', 'propped', 'prosper'],
+      ['proper', 'propped', 'cropper', 'dropper', 'popper', 'prosper'],
       'should suggest alternatives'
     )
 
     st.deepEqual(
       us.suggest('Ghandi'),
-      ['shandy', 'Brandi', 'Ghana', 'Grand', 'Grandee', 'Grands', 'handy'],
+      ['Brandi', 'Ghana', 'Grandee', 'Shanxi', 'hand', 'hands', 'handy'],
       'should suggest alternatives'
     )
 
@@ -301,7 +301,7 @@ test('NSpell()', function (t) {
 
     st.deepEqual(
       us.suggest('collor'),
-      ['color', 'collar', 'colloq'],
+      ['color', 'colloq', 'collar'],
       'should suggest removals'
     )
 

--- a/test/index.js
+++ b/test/index.js
@@ -523,6 +523,12 @@ test('NSpell()', function (t) {
     )
 
     st.deepEqual(
+      us.suggest('abDUL'),
+      ['Abdul'],
+      'should suggest sentence-case for funky case when sentence-case in dictionary'
+    )
+
+    st.deepEqual(
       us.suggest('COLORFU'),
       ['COLORFUL'],
       'should suggest alternatives for upper-case with added letter'

--- a/test/index.js
+++ b/test/index.js
@@ -489,23 +489,23 @@ test('NSpell()', function (t) {
     st.deepEqual(
       us.suggest('dont'),
       [
-        'dent',
         'cont',
-        'font',
-        'wont',
+        'dent',
         'dint',
+        'done',
+        'dong',
+        'font',
         'dolt',
         'don',
         "don't",
         'dona',
-        'done',
-        'dong',
         'dons',
         'dost',
         'dot',
+        'wont',
         'Donn',
         'Mont',
-        'ONT'
+        'Ont'
       ],
       'should suggest alternatives including correct conjunction'
     )


### PR DESCRIPTION
**Update**: For the latest status, see [my latest comment](https://github.com/wooorm/nspell/pull/39#issuecomment-760574350).

This closes issue #37, closes issue #41, and ignores issue #46.

This addresses [a `retext-spell` issue](https://github.com/retextjs/retext-spell/issues/20) I've discovered that is fundamentally [an `nspell` issue](https://github.com/wooorm/nspell/issues/37).

<!---
I'm including a concrete example of the problem for reference.

Differences from `main` are **bolded**:

#### One Example I've tested

- assume the input word is "Twinz"
- assume character `a`is "t" at index 0

1. "T" is uppercase in "Twinz".
2. The first group is "qwertzuop".
    1. **We ignore the position of "t" in the group.**
    2. We split the word "Twinz" at **index 0 into `before`="" and `after` = "winz"**
    3. We iterate thrice to group character `b`="e" 
        - We select an uppercase "E" for **index 0** because "T" was uppercase at index 0

This is how we arrive at the reasonable suggestion of **"Ewinz"**.

**Here is how the same logic leads to the correct solution:**

- assume the input word is "Twinz"
- assume character `a`is **"z" at index 4**

1. **"z" is lowercase** in "Twinz".
2. The first group is "qwertzuop".
    1. **We ignore the position of "z" in the group.**
    2. We split the word "Twinz" at index 4 into `before`="Twin" and `after` = ""
    3. We iterate thrice to group character `b`="e" 
        - We select a **lowercase** "e" for index 4 **because "z" was lowercase at index 4.**

This is how we arrive at the correct suggestion of **"Twine"**.
-->

## Addressing a bigger problem

In `main`, the notion of "Keyboard groups" doesn't really make sense as it replaces at a position (of a character in group) that is unrelated to the original position (of a character in word). **This solution attempts to address that "root problem."**

~~For another solution that ignores issue #41 but solves issue #37, see [my alternative PR](https://github.com/wooorm/nspell/pull/38).~~

This solution **splits the word at the original index** of the character in the input word instead of the unrelated position of the character in the keyboard group. See my review comments.

## It's ready to merge!