### PR TITLE
No longer return all-caps for contractions with missing apostrophes

### DIFF
--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -314,7 +314,7 @@ function generate(context, memory, words, edits) {
         check(before + inject + nextAfter)
 
         // Try upper-case if the original character was upper-cased.
-        if (upper && inject !== "'") {
+        if (upper && inject !== inject.toUpperCase()) {
           inject = inject.toUpperCase()
 
           check(before + inject + after)

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -314,7 +314,7 @@ function generate(context, memory, words, edits) {
         check(before + inject + nextAfter)
 
         // Try upper-case if the original character was upper-cased.
-        if (upper) {
+        if (upper && inject !== "'") {
           inject = inject.toUpperCase()
 
           check(before + inject + after)

--- a/test/index.js
+++ b/test/index.js
@@ -475,6 +475,30 @@ test('NSpell()', function (t) {
       'should include `warn: true` for warnings'
     )
 
+    st.deepEqual(
+      us.suggest('dont'),
+      [
+        'dent',
+        'cont',
+        'font',
+        'wont',
+        'dint',
+        'dolt',
+        'don',
+        "don't",
+        'dona',
+        'done',
+        'dong',
+        'dons',
+        'dost',
+        'dot',
+        'Donn',
+        'Mont',
+        'ONT'
+      ],
+      'should suggest alternatives including correct conjunction'
+    )
+
     st.end()
   })
 


### PR DESCRIPTION
This closes issue #36 

### Problem addressed

In `main`, the suggestions for "dont" included "DON'T" instead of "don't"

The `generate` function gives extra weight to any string added to `result` multiple times.
When `generate` evaluates the uppercased variant of the input "dont", ie "DONT":

- On evaluating the character `N` and adding the character `'`:
    - `generate` injects both `'` and an uppercase `'`.
    
Since `'` and uppercase `'` are identical, in `main` the same string "DON'T" is added twice to `result`.

### Solution proposed

In this PR, we check that the injected character is not `'` (or for that matter, any punctuation character that has no uppercase) before injecting an uppercase variant.

### Possible alternatives

This PR was originally simplified by writing
```
upper && inject !== "'"
```
instead of 
```
upper && inject !== inject.toUpperCase()
```

In English, `'` is the only "lowercase" character in the affix file's `TRY` key that has no uppercase, but that is not the case in other languages. In all cases, the `toUpperCase()` check should actually make sense, as we should never want to simply double the attempted substitutions for characters that have no uppercase. This PR should in general **have no effect on caseless languages** such as Persian, Hebrew, Korean, and Nepali, as `upper` will never be true in those languages (excepting the case where uppercase latin characters have been mixed with non-latin text).

- [Catalan](https://github.com/wooorm/dictionaries/blob/main/dictionaries/ca/index.aff) and [Croatian](https://github.com/wooorm/dictionaries/blob/main/dictionaries/hr/index.aff) includes `'`, `-` and `·`. 
- [Danish](https://github.com/wooorm/dictionaries/blob/main/dictionaries/da/index.aff) and [Latin](https://github.com/wooorm/dictionaries/blob/main/dictionaries/la/index.aff) include `.`.
- [German](https://github.com/wooorm/dictionaries/blob/main/dictionaries/de/index.aff) and [Vietnamese](https://github.com/wooorm/dictionaries/blob/main/dictionaries/vi/index.aff) include `-`.
 - [Esperanto](https://github.com/wooorm/dictionaries/blob/main/dictionaries/de/index.aff), [Irish](https://github.com/wooorm/dictionaries/blob/main/dictionaries/ga/index.aff), [Scottish Gaelic](https://github.com/wooorm/dictionaries/blob/main/dictionaries/gd/index.aff), [Turkish](https://github.com/wooorm/dictionaries/blob/main/dictionaries/tr/index.aff), and [Ukrainian](https://github.com/wooorm/dictionaries/blob/main/dictionaries/uk/index.aff) include `'` and `-`.
 - [Basque](https://github.com/wooorm/dictionaries/blob/main/dictionaries/de/index.aff) includes `'` and `.`.
 - In [Persian](https://github.com/wooorm/dictionaries/blob/main/dictionaries/fa/index.aff), [Hebrew](https://github.com/wooorm/dictionaries/blob/main/dictionaries/he/index.aff), [Korean](https://github.com/wooorm/dictionaries/blob/main/dictionaries/ko/index.aff), and [Nepali](https://github.com/wooorm/dictionaries/blob/main/dictionaries/ne/index.aff) **all characters have no uppercase.**
 - [Frisian](https://github.com/wooorm/dictionaries/blob/main/dictionaries/fy/index.aff) and [Western Frisian](https://github.com/wooorm/dictionaries/blob/main/dictionaries/fy/index.aff) include `'`, `-`, `·`,`0`, `1`, `2`, `3`, `4`, `5`, `6`, and `8`.
- [Galician](https://raw.githubusercontent.com/wooorm/dictionaries/main/dictionaries/gl/index.aff) includes `-` and `·`. 
- [Hungarian](https://github.com/wooorm/dictionaries/blob/main/dictionaries/hu/index.aff) includes `-`, `.`, `&`, and `;`.
- [Luxembourgish](https://github.com/wooorm/dictionaries/blob/main/dictionaries/lb/index.aff) includes `'`, `-`, and `/`.
- [Lithuanian](https://github.com/wooorm/dictionaries/blob/main/dictionaries/lt/index.aff) includes [0x97](https://unicodelookup.com/#0x97), `”`, `¾`, `«`,[0x8D](https://unicodelookup.com/#0x8D) , [0x85](https://unicodelookup.com/#0x85/1), `³`, and [0x99](https://unicodelookup.com/#0x99).
- [Macedonian](https://github.com/wooorm/dictionaries/blob/main/dictionaries/mk/index.aff) includes `-`, `’`, `!`, and `.`.
- [Low German](https://github.com/wooorm/dictionaries/blob/main/dictionaries/nds/index.aff) includes `-` and `.`.
- [Dutch](https://github.com/wooorm/dictionaries/blob/main/dictionaries/nl/index.aff) includes `'`, `-`, `’`, `.`, `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, and `9`.
- [Swedish](https://github.com/wooorm/dictionaries/blob/main/dictionaries/sv/index.aff) includes `:`, `-`, and `.`
