### PR TITLE
Fix capitalization

### DIFF
--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -147,7 +147,7 @@ function suggest(value) {
   values = [value]
   replacement = value.toLowerCase()
 
-  if (value === replacement) {
+  if (value === replacement || currentCase === null) {
     values.push(value.charAt(0).toUpperCase() + replacement.slice(1))
   }
 

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -143,14 +143,12 @@ function suggest(value) {
 
   push.apply(edits, values)
 
-  // Ensure the lower-cased, capitalised, and uppercase values are included.
+  // Ensure the capitalised and uppercase values are included.
   values = [value]
   replacement = value.toLowerCase()
 
   if (value === replacement) {
     values.push(value.charAt(0).toUpperCase() + replacement.slice(1))
-  } else {
-    values.push(replacement)
   }
 
   replacement = value.toUpperCase()
@@ -248,6 +246,7 @@ function generate(context, memory, words, edits) {
   var flags = context.flags
   var result = []
   var upper
+  var nextUpper
   var length
   var index
   var word
@@ -261,6 +260,7 @@ function generate(context, memory, words, edits) {
   var nextCharacter
   var inject
   var offset
+  var currentCase
 
   // Check the pre-generated edits.
   length = edits && edits.length
@@ -280,8 +280,10 @@ function generate(context, memory, words, edits) {
     before = ''
     character = ''
     nextAfter = word
+    currentCase = casing(word)
     nextNextAfter = word.slice(1)
     nextCharacter = word.charAt(0)
+    nextUpper = nextCharacter.toLowerCase() !== nextCharacter
     position = -1
     count = word.length + 1
 
@@ -293,7 +295,23 @@ function generate(context, memory, words, edits) {
       nextNextAfter = nextAfter.slice(1)
       character = nextCharacter
       nextCharacter = word.charAt(position + 1)
-      upper = character.toLowerCase() !== character
+      upper = nextUpper
+      if (nextCharacter) {
+        nextUpper = nextCharacter.toLowerCase() !== nextCharacter
+      }
+
+      if (nextAfter && upper !== nextUpper) {
+        // Remove.
+        check(before + switchCase(nextAfter))
+
+        // Switch.
+        check(
+          before +
+            switchCase(nextCharacter) +
+            switchCase(character) +
+            nextNextAfter
+        )
+      }
 
       // Remove.
       check(before + nextAfter)
@@ -309,14 +327,19 @@ function generate(context, memory, words, edits) {
       while (++offset < characterLength) {
         inject = characters[offset]
 
-        // Add and replace.
-        check(before + inject + after)
-        check(before + inject + nextAfter)
-
         // Try upper-case if the original character was upper-cased.
         if (upper && inject !== inject.toUpperCase()) {
+          if (currentCase !== 's') {
+            check(before + inject + after)
+            check(before + inject + nextAfter)
+          }
+
           inject = inject.toUpperCase()
 
+          check(before + inject + after)
+          check(before + inject + nextAfter)
+        } else {
+          // Add and replace.
           check(before + inject + after)
           check(before + inject + nextAfter)
         }
@@ -349,5 +372,14 @@ function generate(context, memory, words, edits) {
     if (state) {
       memory.weighted[value]++
     }
+  }
+
+  function switchCase(fragment) {
+    var first = fragment.charAt(0)
+    if (first.toLowerCase() === first) {
+      return first.toUpperCase() + fragment.slice(1)
+    }
+
+    return first.toLowerCase() + fragment.slice(1)
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -499,6 +499,24 @@ test('NSpell()', function (t) {
       'should suggest alternatives including correct conjunction'
     )
 
+    st.deepEqual(
+      us.suggest('Iffect'),
+      ['Affect', 'Effect', 'Infect'],
+      'should suggest sentence-case with replaced first character'
+    )
+
+    st.deepEqual(
+      us.suggest('Acnada'),
+      ['Canada'],
+      'should suggest sentence-case with swapped first character'
+    )
+
+    st.deepEqual(
+      us.suggest('COLORFU'),
+      ['COLORFUL'],
+      'should suggest alternatives for upper-case with added letter'
+    )
+
     st.end()
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -512,6 +512,12 @@ test('NSpell()', function (t) {
     )
 
     st.deepEqual(
+      us.suggest('abDUL'),
+      ['Abdul'],
+      'should suggest sentence-case for funky case when sentence-case in dictionary'
+    )
+
+    st.deepEqual(
       us.suggest('COLORFU'),
       ['COLORFUL'],
       'should suggest alternatives for upper-case with added letter'


### PR DESCRIPTION
This contains fixes previously bundled in PR #39.
This adds new tests (that currently fail on `main`), and it breaks some existing tests.
Before we could merge this PR, we would need to merge PR #39 and PR #44.

I've found a few miscellaneous capitalization issues with main that I thought I'd address. I'm operating under a few assumptions I've made by observing the general behavior of `nspell/main`:

- UPPERCASE INPUT should always produce UPPERCASE OUTPUT
- Sentence Case Input should produce Sentence Case Output
   - unless the output is in the dictionary as UPPERCASE
- lowercase input should output lowercase
   - unless the output is in the dictionary as Sentence Case or UPPERCASE 
- FuNkY caSE should output FuNkY caSE
   - unless the output is in the dictionary as Sentence Case or UPPERCASE 